### PR TITLE
Add asset type filter

### DIFF
--- a/graph_asset_inventory_api/api/assets.py
+++ b/graph_asset_inventory_api/api/assets.py
@@ -14,11 +14,11 @@ from graph_asset_inventory_api.inventory import (
 from graph_asset_inventory_api.api import AssetResp
 
 
-def get_assets(page=None, size=100):
+def get_assets(page=None, size=100, asset_type=None):
     """Request handler for the API endpoint ``GET /v1/assets``."""
     cli = get_inventory_client()
 
-    assets = cli.assets(page, size)
+    assets = cli.assets(page, size, asset_type)
 
     resp = [AssetResp.from_dbasset(t).__dict__ for t in assets]
     return resp, 200

--- a/graph_asset_inventory_api/inventory/client.py
+++ b/graph_asset_inventory_api/inventory/client.py
@@ -144,13 +144,14 @@ class InventoryClient:
 
     # Assets.
 
-    def assets(self, page_idx=None, page_size=100):
-        """Returns all assets if ``page_idx`` is None. Otherwise it returns the
-        page of assets with index ``page_idx`` and size ``page_size``. By
-        default, the page size is 100 items."""
+    def assets(self, page_idx=None, page_size=100, type=None):
+        """Returns all assets (filtered by `type` if any is specified) if
+        ``page_idx`` is None. Otherwise it returns the page of assets with index
+        ``page_idx`` and size ``page_size``. By default, the page size is 100
+        items."""
 
         vassets = self._g \
-            .assets()
+            .assets(type)
 
         if page_idx is not None:
             offset = page_idx * page_size

--- a/graph_asset_inventory_api/inventory/client.py
+++ b/graph_asset_inventory_api/inventory/client.py
@@ -146,9 +146,9 @@ class InventoryClient:
 
     def assets(self, page_idx=None, page_size=100, type=None):
         """Returns all assets (filtered by `type` if any is specified) if
-        ``page_idx`` is None. Otherwise it returns the page of assets with index
-        ``page_idx`` and size ``page_size``. By default, the page size is 100
-        items."""
+        ``page_idx`` is None. Otherwise it returns the page of assets with
+        index ``page_idx`` and size ``page_size``. By default, the page size is
+        100 items."""
 
         vassets = self._g \
             .assets(type)

--- a/graph_asset_inventory_api/inventory/client.py
+++ b/graph_asset_inventory_api/inventory/client.py
@@ -144,14 +144,14 @@ class InventoryClient:
 
     # Assets.
 
-    def assets(self, page_idx=None, page_size=100, type=None):
+    def assets(self, page_idx=None, page_size=100, asset_type=None):
         """Returns all assets (filtered by `type` if any is specified) if
         ``page_idx`` is None. Otherwise it returns the page of assets with
         index ``page_idx`` and size ``page_size``. By default, the page size is
         100 items."""
 
         vassets = self._g \
-            .assets(type)
+            .assets(asset_type)
 
         if page_idx is not None:
             offset = page_idx * page_size

--- a/graph_asset_inventory_api/inventory/dsl.py
+++ b/graph_asset_inventory_api/inventory/dsl.py
@@ -179,12 +179,12 @@ class InventoryTraversalSource(GraphTraversalSource):
 
     # Assets.
 
-    def assets(self, type=None):
+    def assets(self, asset_type=None):
         """Returns all the ``Asset`` vertices."""
-        r = self.V().is_asset()
-        if type is None:
-            return r
-        return r.has('type', type)
+        assets = self.V().is_asset()
+        if asset_type is None:
+            return assets
+        return assets.has('type', asset_type)
 
     def asset(self, vid):
         """Returns an ``Asset`` vertex with a given vertex id ``vid``."""

--- a/graph_asset_inventory_api/inventory/dsl.py
+++ b/graph_asset_inventory_api/inventory/dsl.py
@@ -179,9 +179,12 @@ class InventoryTraversalSource(GraphTraversalSource):
 
     # Assets.
 
-    def assets(self):
+    def assets(self, type=None):
         """Returns all the ``Asset`` vertices."""
-        return self.V().is_asset()
+        r = self.V().is_asset()
+        if type == None:
+            return r
+        return r.has('type', type)
 
     def asset(self, vid):
         """Returns an ``Asset`` vertex with a given vertex id ``vid``."""

--- a/graph_asset_inventory_api/inventory/dsl.py
+++ b/graph_asset_inventory_api/inventory/dsl.py
@@ -182,7 +182,7 @@ class InventoryTraversalSource(GraphTraversalSource):
     def assets(self, type=None):
         """Returns all the ``Asset`` vertices."""
         r = self.V().is_asset()
-        if type == None:
+        if type is None:
             return r
         return r.has('type', type)
 

--- a/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
+++ b/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
@@ -135,6 +135,12 @@ paths:
           schema:
             type: integer
           required: false
+        - in: query
+          name: asset_type
+          description: Type of the assets.
+          schema:
+            type: string
+          required: false
       responses:
         '200':
           description: A JSON array of assets.

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -40,6 +40,20 @@ def test_get_assets_pagination_missing_size(flask_cli, init_api_assets):
     assert compare_unsorted_list(data, init_api_assets, lambda x: x['id'])
 
 
+def test_get_assets_with_type(flask_cli, init_api_assets):
+    """Tests the API endpoint ``GET /v1/assets`` filtering by a concrete asset
+    type"""
+    resp = flask_cli.get('/v1/assets?asset_type=type1')
+
+    assert resp.status_code == 200
+
+    data = json.loads(resp.data)
+    expected = [
+        asset for asset in init_api_assets if asset['type'] == 'type1'
+    ]
+    assert compare_unsorted_list(data, expected, lambda x: x['id'])
+
+
 def test_post_assets(flask_cli, init_api_assets):
     """Tests the API endpoint ``POST /v1/assets``."""
     asset_id = AssetID('new_type', 'new_identifier')

--- a/tests/test_inventory_client.py
+++ b/tests/test_inventory_client.py
@@ -217,7 +217,7 @@ def test_assets_type(cli, init_assets):
         asset for asset in init_assets if asset.asset_id.type == 'type0'
     ]
     assert compare_unsorted_list(
-        cli.assets(type='type0'), expected, lambda x: x.vid)
+        cli.assets(asset_type='type0'), expected, lambda x: x.vid)
 
 
 def test_assets_type_pagination(cli, init_assets):
@@ -229,7 +229,7 @@ def test_assets_type_pagination(cli, init_assets):
     expected = expected[:1]
     assert compare_unsorted_list(
         cli.assets(
-            page_idx=0, page_size=1, type='type0'
+            page_idx=0, page_size=1, asset_type='type0'
         ),
         expected, lambda x: x.vid
     )

--- a/tests/test_inventory_client.py
+++ b/tests/test_inventory_client.py
@@ -213,17 +213,26 @@ def test_assets_pagination(cli, init_assets):
 def test_assets_type(cli, init_assets):
     """Tests the filter ``type`` of the method ``assets`` of the class
     ``InventoryClient``."""
+    expected = [
+        asset for asset in init_assets if asset.asset_id.type == 'type0'
+    ]
     assert compare_unsorted_list(
-        cli.assets(type='type0'), [asset for asset in init_assets if asset.asset_id.type == 'type0'], lambda x: x.vid)
+        cli.assets(type='type0'), expected, lambda x: x.vid)
 
 
-def test_assets_type(cli, init_assets):
+def test_assets_type_pagination(cli, init_assets):
     """Tests the filter ``type`` and the ``pagination`` params of the method
     ``assets`` of the class ``InventoryClient``."""
-    expected = [asset for asset in init_assets if asset.asset_id.type == 'type0']
+    expected = [
+        asset for asset in init_assets if asset.asset_id.type == 'type0'
+    ]
     expected = expected[:1]
     assert compare_unsorted_list(
-        cli.assets(page_idx=0, page_size=1, type='type0'), expected, lambda x: x.vid)
+        cli.assets(
+            page_idx=0, page_size=1, type='type0'
+        ),
+        expected, lambda x: x.vid
+    )
 
 
 def test_asset(cli, init_assets):

--- a/tests/test_inventory_client.py
+++ b/tests/test_inventory_client.py
@@ -210,6 +210,22 @@ def test_assets_pagination(cli, init_assets):
         cli.assets(0, 1000), init_assets, lambda x: x.vid)
 
 
+def test_assets_type(cli, init_assets):
+    """Tests the filter ``type`` of the method ``assets`` of the class
+    ``InventoryClient``."""
+    assert compare_unsorted_list(
+        cli.assets(type='type0'), [asset for asset in init_assets if asset.asset_id.type == 'type0'], lambda x: x.vid)
+
+
+def test_assets_type(cli, init_assets):
+    """Tests the filter ``type`` and the ``pagination`` params of the method
+    ``assets`` of the class ``InventoryClient``."""
+    expected = [asset for asset in init_assets if asset.asset_id.type == 'type0']
+    expected = expected[:1]
+    assert compare_unsorted_list(
+        cli.assets(page_idx=0, page_size=1, type='type0'), expected, lambda x: x.vid)
+
+
 def test_asset(cli, init_assets):
     """Tests the method ``asset`` of the class ``InventoryClient``."""
     asset = cli.asset(init_assets[2].vid)


### PR DESCRIPTION
This PR adds the capability of querying assets filtering by type to the [GET] /assets
endpoint.
For instance, a request like: ``[GET] /assets?asset_type=AWSAccount`` will return only the assets that are AWSAccounts.   