### PR TITLE
api/{api,inventory}: add valid_at filter to assets queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     "]
 
   graph-notebook-local:
-    image: adevinta/graph-notebook-docker:v1.0.0
+    image: adevinta/graph-notebook-docker:v1.1.0
     ports:
       - "127.0.0.1:8888:8888"
     volumes:
@@ -56,7 +56,7 @@ services:
         condition: service_healthy
 
   graph-notebook-test:
-    image: adevinta/graph-notebook-docker:v1.0.0
+    image: adevinta/graph-notebook-docker:v1.1.0
     ports:
       - "127.0.0.1:8889:8888"
     volumes:

--- a/graph_asset_inventory_api/api/assets.py
+++ b/graph_asset_inventory_api/api/assets.py
@@ -14,11 +14,20 @@ from graph_asset_inventory_api.inventory import (
 from graph_asset_inventory_api.api import AssetResp
 
 
-def get_assets(page=None, size=100, asset_type=None, asset_identifier=None):
+def get_assets(
+    page=None,
+    size=100,
+    asset_type=None,
+    asset_identifier=None,
+    valid_at=None
+):
     """Request handler for the API endpoint ``GET /v1/assets``."""
     cli = get_inventory_client()
 
-    assets = cli.assets(page, size, asset_type, asset_identifier)
+    if valid_at is not None:
+        valid_at = dateutil.parser.isoparse(valid_at)
+
+    assets = cli.assets(page, size, asset_type, asset_identifier, valid_at)
 
     resp = [AssetResp.from_dbasset(t).__dict__ for t in assets]
     return resp, 200

--- a/graph_asset_inventory_api/inventory/client.py
+++ b/graph_asset_inventory_api/inventory/client.py
@@ -159,6 +159,7 @@ class InventoryClient:
         page_size=100,
         asset_type=None,
         asset_identifier=None,
+        valid_at=None,
         universe=CURRENT_UNIVERSE
     ):  # pylint: disable=too-many-arguments
         """Returns all the assets belonging to the specified
@@ -168,7 +169,7 @@ class InventoryClient:
         page size is 100 items."""
 
         vassets = self._g \
-            .assets(universe, asset_type, asset_identifier)
+            .assets(universe, asset_type, asset_identifier, valid_at)
 
         if page_idx is not None:
             offset = page_idx * page_size

--- a/graph_asset_inventory_api/inventory/dsl.py
+++ b/graph_asset_inventory_api/inventory/dsl.py
@@ -325,7 +325,13 @@ class InventoryTraversalSource(GraphTraversalSource):
 
     # Assets.
 
-    def assets(self, universe, asset_type=None, asset_identifier=None):
+    def assets(
+        self,
+        universe,
+        asset_type=None,
+        asset_identifier=None,
+        valid_at=None
+    ):
         """Returns all the ``Asset`` vertices that belong to a ``Universe``."""
         assets = self \
             .V() \
@@ -337,6 +343,12 @@ class InventoryTraversalSource(GraphTraversalSource):
 
         if asset_identifier is not None:
             assets = assets.has('identifier', asset_identifier)
+
+        if valid_at is not None:
+            assets = assets.and_(
+                __.has("first_seen", P.lte(valid_at)),
+                __.has("expiration", P.gte(valid_at))
+            )
 
         return assets
 

--- a/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
+++ b/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
@@ -153,6 +153,13 @@ paths:
           schema:
             type: string
           required: false
+        - in: query
+          name: valid_at
+          description: Time at which the assets must exist and not being expired.
+          schema:
+            type: string
+            format: date-time
+          required: false
       responses:
         '200':
           description: A JSON array of assets.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,6 @@
 # graph_asset_inventory_api dependencies.
 Flask==2.0.0
+werkzeug==2.0.3
 connexion[swagger-ui]==2.7.0
 gunicorn==20.1.0
 gremlinpython==3.5.1

--- a/tests/test_api_assets.py
+++ b/tests/test_api_assets.py
@@ -1,6 +1,7 @@
 """Tests for the Asset Inventory API."""
 
 import json
+import urllib.parse
 from datetime import datetime
 
 from helpers import compare_unsorted_list
@@ -82,6 +83,27 @@ def test_get_assets_by_type_identifier(flask_cli, init_api_assets):
     expected = [
         asset for asset in init_api_assets
         if asset['type'] == 'type1' and asset['identifier'] == 'identifier1'
+    ]
+    assert compare_unsorted_list(data, expected, lambda x: x['id'])
+
+
+def test_get_assets_by_valid_at(flask_cli, init_valid_at_api_assets):
+    """Tests the API endpoint ``GET /v1/assets`` filtering by a concrete
+    ``valid_at`` time."""
+    valid_at = '2010-07-04T01:00:00+00:00'
+    valid_at_q = urllib.parse.quote_plus(valid_at)
+    valid_at_dt = datetime.fromisoformat(valid_at)
+
+    resp = flask_cli.get(f'/v1/assets?valid_at={valid_at_q}')
+
+    assert resp.status_code == 200
+
+    data = json.loads(resp.data)
+    expected = [
+        asset for asset in init_valid_at_api_assets
+        if (datetime.fromisoformat(asset['first_seen'])
+            <= valid_at_dt <=
+            datetime.fromisoformat(asset['expiration']))
     ]
     assert compare_unsorted_list(data, expected, lambda x: x['id'])
 

--- a/tests/test_inventory_client.py
+++ b/tests/test_inventory_client.py
@@ -382,6 +382,25 @@ def test_assets_type_pagination(cli, init_assets):
     )
 
 
+def test_assets_valid_at(cli, init_valid_at_assets):
+    """Tests the filter ``valid_at`` param of the method ``assets`` of the
+    class ``InventoryClient``."""
+    valid_at = datetime.fromisoformat('2010-07-04T01:00:00+00:00')
+
+    expected = [
+        asset
+        for asset in init_valid_at_assets
+        if (asset.time_attr.first_seen
+            <= valid_at <=
+            asset.time_attr.expiration)
+    ]
+    assert compare_unsorted_list(
+        cli.assets(valid_at=valid_at),
+        expected,
+        lambda x: x.vid,
+    )
+
+
 def test_asset(cli, init_assets):
     """Tests the method ``asset`` of the class ``InventoryClient``."""
     asset = cli.asset(init_assets[2].vid)


### PR DESCRIPTION
This PR adds a `valid_at` filter to allow Asset Inventory client and API users
to retrieve only valid assets (i.e. existing and non expired assets).