### PR TITLE
api, tests: add endpoint /v1/assets/{id}/children

### DIFF
--- a/graph_asset_inventory_api/api/parents.py
+++ b/graph_asset_inventory_api/api/parents.py
@@ -68,3 +68,19 @@ def delete_assets_child_id_parents_parent_id(child_id, parent_id):
 
     return connexion.problem(
         404, 'Not Found', f'parent not found: {parent_id}')
+
+
+# pylint: disable=redefined-builtin
+def get_assets_id_children(id, page=None, size=100):
+    """Request handler for the API endpoint ``GET
+    /v1/assets/{id}/children``."""
+    cli = get_inventory_client()
+
+    children = None
+    try:
+        children = cli.children(id, page, size)
+    except NotFoundError:
+        return connexion.problem(404, 'Not Found', 'ID not found')
+
+    resp = [ParentOfResp.from_dbparentof(po).__dict__ for po in children]
+    return resp, 200

--- a/graph_asset_inventory_api/inventory/dsl.py
+++ b/graph_asset_inventory_api/inventory/dsl.py
@@ -494,7 +494,7 @@ class InventoryTraversalSource(GraphTraversalSource):
         return self.E(eid).is_parent_of()
 
     def parents(self, asset_vid):
-        """Returns the incoming ``parent_of`` edges of the Asset vertex with ID
+        """Returns the ingoing ``parent_of`` edges of the Asset vertex with ID
         ``vid``."""
         return self \
             .asset(asset_vid) \
@@ -553,6 +553,14 @@ class InventoryTraversalSource(GraphTraversalSource):
             .sideEffect(__.drop()) \
             .count()
 
+    def children(self, asset_vid):
+        """Returns the outgoing ``parent_of`` edges of the Asset vertex with ID
+        ``vid``."""
+        return self \
+            .asset(asset_vid) \
+            .outE() \
+            .is_parent_of()
+
     # Owners.
 
     def owns(self, eid):
@@ -560,7 +568,7 @@ class InventoryTraversalSource(GraphTraversalSource):
         return self.E(eid).is_owns()
 
     def owners(self, asset_vid):
-        """Returns the incoming ``owns`` edges of the Asset vertex with ID
+        """Returns the ingoing ``owns`` edges of the Asset vertex with ID
         ``vid``."""
         return self \
             .asset(asset_vid) \

--- a/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
+++ b/graph_asset_inventory_api/openapi/graph-asset-inventory-api.yaml
@@ -274,7 +274,7 @@ paths:
 
     get:
       operationId: graph_asset_inventory_api.api.parents.get_assets_id_parents
-      summary: Returns the list of child-of relationships of an asset.
+      summary: Returns the list of parent-of relationships of an asset.
       tags:
         - Assets
         - Parents
@@ -351,7 +351,7 @@ paths:
 
     delete:
       operationId: graph_asset_inventory_api.api.parents.delete_assets_child_id_parents_parent_id
-      summary: Deletes a child-of relationship.
+      summary: Deletes a parent-of relationship.
       tags:
         - Assets
         - Parents
@@ -361,6 +361,48 @@ paths:
           description: The relationship has been deleted successfully.
         '404':
           description: At least one of the assets or the relationship were not found.
+
+  /v1/assets/{id}/children:
+    parameters:
+      - in: path
+        name: id
+        description: ID of the asset.
+        schema:
+          type: string
+          format: uuid
+        required: true
+
+    get:
+      operationId: graph_asset_inventory_api.api.parents.get_assets_id_children
+      summary: Returns the list of outgoing parent-of relationships of an asset.
+      tags:
+        - Assets
+        - Parents
+        - v1
+      parameters:
+        - in: query
+          name: page
+          description: Index of the page.
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: size
+          description: Number of results per page.
+          schema:
+            type: integer
+          required: false
+      responses:
+        '200':
+          description: A JSON array of relationships.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ParentOfResp'
+        '404':
+          description: The asset was not found.
 
   /v1/assets/{id}/owners:
     parameters:

--- a/tests/test_api_parents.py
+++ b/tests/test_api_parents.py
@@ -229,3 +229,15 @@ def test_delete_assets_id_not_found_error(flask_cli, init_api_parents):
         init_api_parents[child],
         lambda x: x['id'],
     )
+
+
+def test_get_assets_id_children(flask_cli, init_api_children):
+    """Tests the API endpoint ``GET /v1/assets/{id}/children``."""
+
+    for parent_id, children in init_api_children.items():
+        resp = flask_cli.get(f'/v1/assets/{parent_id}/children')
+
+        assert resp.status_code == 200
+
+        data = json.loads(resp.data)
+        assert compare_unsorted_list(data, children, lambda x: x['id'])

--- a/tests/test_inventory_client.py
+++ b/tests/test_inventory_client.py
@@ -956,6 +956,13 @@ def test_drop_parent_of_not_found_error(cli, unknown_uuid):
     assert exc_info.value.name == unknown_uuid
 
 
+def test_children(cli, init_children):
+    """Tests the method ``children`` of the class ``InventoryClient`."""
+    for vid, children in init_children.items():
+        assert compare_unsorted_list(
+            cli.children(vid), children, lambda x: x.eid)
+
+
 # Owners.
 
 


### PR DESCRIPTION
The Security Graph Asset Inventory API allows to list the parents of a given
asset. In other words, it allows to list the ingoing parent-of relationships.
However, sometimes we need to get the children of a given assets. That means
getting the outgoing parent-of relationships. This PR add support for this.